### PR TITLE
use default status bar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -46,7 +46,7 @@
     <link rel="manifest" href="manifest.json">
 
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="msapplication-tap-highlight" content="no">
 
     <style>


### PR DESCRIPTION
Let iOS choose the status bar color.  This PR is a little subjective as in some cases a black status bar might actually look better than the default.  It just depends on what slide you're looking at.  I'd completely understand if your preference was to leave this as is.

![deckdeckgo-site](https://user-images.githubusercontent.com/57374/52791656-0c54f000-302f-11e9-925f-6ce3395ff9fe.png)
